### PR TITLE
fixed horizontal scroll provided by AOS lib

### DIFF
--- a/src/css/general.css
+++ b/src/css/general.css
@@ -11,6 +11,10 @@
 
   scroll-behavior: smooth;
 }
+html,
+body {
+  overflow-x: hidden;
+}
 
 body {
   font-family: 'Manrope', sans-serif;

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap"
       rel="stylesheet"
     />
-    <!-- <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" /> -->
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/2.0.0/modern-normalize.min.css"


### PR DESCRIPTION
Added `overflow-x: hidden;` for body to prevent horizontal scroll witch is caused by AOS on `.about-us-photo-block` container